### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,4 +1,6 @@
 name: publish to ghcr
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5V/security/code-scanning/1](https://github.com/French-CSGO/G5V/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow (either at the top level or per-job) that grants only the scopes required. This documents the required permissions and prevents the workflow from unintentionally inheriting broader defaults.

For this particular workflow, the job just checks out code, installs dependencies, builds, and pushes Docker images to GHCR using a personal access token stored in `secrets.TOKEN`. It doesn’t create or modify issues, PRs, or use `GITHUB_TOKEN` for write operations. The minimal sensible permission set is therefore `contents: read` so the job can read the repository contents via `actions/checkout`. Because there is only one job, the cleanest change is to add a top-level `permissions:` block after the `name:` (or after `on:`) that applies to all jobs.

Concretely:
- Edit `.github/workflows/ghcr.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  near the top of the file (e.g., between lines 1 and 2, or after the `on:` block). This will not affect existing functionality because the workflow already only needs read access to the repo contents, and all registry writes use the separate `secrets.TOKEN`.

No new methods, imports, or definitions are needed since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
