### PR TITLE
Image generator cleanup, map MVP/stats boxes, and admin pause-all-live

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,6 +1,7 @@
 name: publish to ghcr
 permissions:
   contents: read
+  packages: write
 on:
   workflow_dispatch:
   pull_request:

--- a/src/components/ImageFCTable.vue
+++ b/src/components/ImageFCTable.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-simple-table dense class="mb-2">
+    <thead>
+      <tr>
+        <th style="width:232px">Champ</th>
+        <th style="width:52px">Actif</th>
+        <th style="width:80px">Police</th>
+        <th style="width:42px">Coul.</th>
+        <th style="width:64px">Taille</th>
+        <th style="width:48px">Gras</th>
+        <th style="width:90px">X</th>
+        <th style="width:90px">Y</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="f in fields" :key="f.key">
+        <td class="caption font-weight-medium">{{ f.label }}</td>
+        <td>
+          <v-switch
+            v-model="section[f.key].enabled"
+            color="primary" inset dense hide-details class="mt-0 pt-0"
+          />
+        </td>
+        <td>
+          <v-combobox
+            v-model="section[f.key].font"
+            :items="fontList"
+            outlined dense hide-details
+          />
+        </td>
+        <td>
+          <input type="color" v-model="section[f.key].color" class="color-input" />
+        </td>
+        <td>
+          <v-text-field
+            v-model.number="section[f.key].size"
+            type="number" outlined dense hide-details
+          />
+        </td>
+        <td>
+          <v-checkbox v-model="section[f.key].bold" hide-details class="mt-0 pt-0" />
+        </td>
+        <td>
+          <v-text-field
+            v-model.number="section[f.key].x"
+            type="number" outlined dense hide-details
+          />
+        </td>
+        <td>
+          <v-text-field
+            v-model.number="section[f.key].y"
+            type="number" outlined dense hide-details
+          />
+        </td>
+      </tr>
+    </tbody>
+  </v-simple-table>
+</template>
+
+<script>
+export default {
+  name: "ImageFCTable",
+  props: {
+    fields:   { type: Array,  required: true },   // [{ key, label }]
+    section:  { type: Object, required: true },   // reactive settings sub-object
+    fontList: { type: Array,  default: () => [] },
+  },
+};
+</script>

--- a/src/components/ImageFXTable.vue
+++ b/src/components/ImageFXTable.vue
@@ -1,0 +1,62 @@
+<template>
+  <v-simple-table dense class="mb-2">
+    <thead>
+      <tr>
+        <th style="width:232px">Champ</th>
+        <th style="width:52px">Actif</th>
+        <th style="width:80px">Police</th>
+        <th style="width:42px">Coul.</th>
+        <th style="width:64px">Taille</th>
+        <th style="width:48px">Gras</th>
+        <th style="width:90px">X</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="f in fields" :key="f.key">
+        <td class="caption font-weight-medium">{{ f.label }}</td>
+        <td>
+          <v-switch
+            v-model="section[f.key].enabled"
+            color="primary" inset dense hide-details class="mt-0 pt-0"
+          />
+        </td>
+        <td>
+          <v-combobox
+            v-model="section[f.key].font"
+            :items="fontList"
+            outlined dense hide-details
+          />
+        </td>
+        <td>
+          <input type="color" v-model="section[f.key].color" class="color-input" />
+        </td>
+        <td>
+          <v-text-field
+            v-model.number="section[f.key].size"
+            type="number" outlined dense hide-details
+          />
+        </td>
+        <td>
+          <v-checkbox v-model="section[f.key].bold" hide-details class="mt-0 pt-0" />
+        </td>
+        <td>
+          <v-text-field
+            v-model.number="section[f.key].x"
+            type="number" outlined dense hide-details
+          />
+        </td>
+      </tr>
+    </tbody>
+  </v-simple-table>
+</template>
+
+<script>
+export default {
+  name: "ImageFXTable",
+  props: {
+    fields:   { type: Array,  required: true },   // [{ key, label }]
+    section:  { type: Object, required: true },
+    fontList: { type: Array,  default: () => [] },
+  },
+};
+</script>

--- a/src/components/MatchesTable.vue
+++ b/src/components/MatchesTable.vue
@@ -1,4 +1,5 @@
 <template>
+  <div>
   <v-data-table
     item-key="name"
     class="elevation-1"
@@ -64,9 +65,34 @@
           </v-toolbar-title>
         </v-toolbar>
       </div>
+      <div v-else-if="isAdmin">
+        <v-toolbar flat>
+          <v-toolbar-title>
+            <v-btn
+              color="warning"
+              class="mr-2"
+              @click="pauseAllLive"
+              :loading="pausePending"
+            >
+              {{ $t("Matches.PauseAllLive") }}
+            </v-btn>
+            <v-btn
+              color="success"
+              @click="unpauseAllLive"
+              :loading="unpausePending"
+            >
+              {{ $t("Matches.UnpauseAllLive") }}
+            </v-btn>
+          </v-toolbar-title>
+        </v-toolbar>
+      </div>
       <div v-else />
     </template>
   </v-data-table>
+  <v-snackbar v-model="actionSnackbar" timeout="4000">
+    {{ actionMessage }}
+  </v-snackbar>
+  </div>
 </template>
 
 <script>
@@ -81,7 +107,11 @@ export default {
       isThereCancelledMatches: false,
       totalMatches: -1,
       options: {},
-      deletePending: false
+      deletePending: false,
+      pausePending: false,
+      unpausePending: false,
+      actionSnackbar: false,
+      actionMessage: ""
     };
   },
   computed: {
@@ -114,6 +144,12 @@ export default {
     },
     isMyMatches() {
       return this.$route.path == "/mymatches";
+    },
+    isAdmin() {
+      return (
+        Number(this.user?.admin) === 1 ||
+        Number(this.user?.super_admin) === 1
+      );
     }
   },
   watch: {
@@ -206,6 +242,40 @@ export default {
       this.isLoading = true;
       this.isThereCancelledMatches = false;
       await this.pageUpdate();
+    },
+    async getLiveMatches() {
+      let matches = await this.GetAllMatches();
+      if (typeof matches == "string") matches = [];
+      return matches.filter(
+        match =>
+          match.end_time == null &&
+          (match.cancelled == 0 || match.cancelled == null) &&
+          match.start_time != null
+      );
+    },
+    async pauseAllLive() {
+      this.pausePending = true;
+      const liveMatches = await this.getLiveMatches();
+      await Promise.all(
+        liveMatches.map(match => this.PauseMatch(match.id))
+      );
+      this.pausePending = false;
+      this.actionMessage = this.$t("Matches.PauseAllLiveDone", {
+        count: liveMatches.length
+      });
+      this.actionSnackbar = true;
+    },
+    async unpauseAllLive() {
+      this.unpausePending = true;
+      const liveMatches = await this.getLiveMatches();
+      await Promise.all(
+        liveMatches.map(match => this.UnpauseMatch(match.id))
+      );
+      this.unpausePending = false;
+      this.actionMessage = this.$t("Matches.UnpauseAllLiveDone", {
+        count: liveMatches.length
+      });
+      this.actionSnackbar = true;
     }
   }
 };

--- a/src/translations/translations.json
+++ b/src/translations/translations.json
@@ -191,6 +191,10 @@
       "Server": "Server",
       "Owner": "Owner",
       "DeleteButton": "Delete My Cancelled Matches",
+      "PauseAllLive": "Pause all live matches",
+      "UnpauseAllLive": "Unpause all live matches",
+      "PauseAllLiveDone": "{count} live match(es) paused",
+      "UnpauseAllLiveDone": "{count} live match(es) unpaused",
       "Versus": "vs"
     },
     "Metrics": {
@@ -726,6 +730,10 @@
       "Server": "Serveur",
       "Owner": "Propriétaire",
       "DeleteButton": "Supprimer mes matchs annulés",
+      "PauseAllLive": "Mettre en pause tous les matchs en cours",
+      "UnpauseAllLive": "Reprendre tous les matchs en cours",
+      "PauseAllLiveDone": "{count} match(s) en cours mis en pause",
+      "UnpauseAllLiveDone": "{count} match(s) en cours repris",
       "Versus": "vs"
     },
     "Metrics": {
@@ -1257,6 +1265,10 @@
       "Server": "サーバ",
       "Owner": "オーナー",
       "DeleteButton": "キャンセルされたマッチを削除する",
+      "PauseAllLive": "進行中の全マッチを一時停止",
+      "UnpauseAllLive": "進行中の全マッチを再開",
+      "PauseAllLiveDone": "{count} 件の進行中マッチを一時停止しました",
+      "UnpauseAllLiveDone": "{count} 件の進行中マッチを再開しました",
       "Versus": "対"
     },
     "Metrics": {

--- a/src/views/CastView.vue
+++ b/src/views/CastView.vue
@@ -85,13 +85,13 @@
                       </v-btn>
                     </div>
                   </td>
-                  <td class="text-center">
-                    <div class="d-flex flex-column" style="gap:2px">
+                  <td class="text-center py-2">
+                    <div class="d-flex flex-column" style="gap:5px">
                       <div
                         v-for="(map, i) in match.maps"
                         :key="'img-a-'+match.id+'-'+i"
                         class="d-flex"
-                        style="gap:2px"
+                        style="gap:3px"
                       >
                         <v-btn
                           x-small dark color="teal"
@@ -108,7 +108,7 @@
                           <v-icon x-small left>mdi-star</v-icon>MVP
                         </v-btn>
                       </div>
-                      <div class="d-flex" style="gap:2px">
+                      <div class="d-flex" style="gap:3px">
                         <v-btn
                           x-small dark color="teal darken-2"
                           :href="'/api/image/match/' + match.id"
@@ -179,13 +179,13 @@
                     </template>
                     <span v-else class="grey--text">—</span>
                   </td>
-                  <td class="text-center">
-                    <div class="d-flex flex-column" style="gap:2px; align-items:center">
+                  <td class="text-center py-2">
+                    <div class="d-flex flex-column" style="gap:5px; align-items:center">
                       <div
                         v-for="(map, i) in match.maps"
                         :key="'img-f-'+match.id+'-'+i"
                         class="d-flex"
-                        style="gap:2px"
+                        style="gap:3px"
                       >
                         <v-btn
                           x-small dark color="teal"
@@ -202,7 +202,7 @@
                           <v-icon x-small left>mdi-star</v-icon>MVP
                         </v-btn>
                       </div>
-                      <div class="d-flex" style="gap:2px">
+                      <div class="d-flex" style="gap:3px">
                         <v-btn
                           x-small dark color="teal darken-2"
                           :href="'/api/image/match/' + match.id"

--- a/src/views/ImageSettings.vue
+++ b/src/views/ImageSettings.vue
@@ -42,88 +42,8 @@
           </v-row>
 
           <v-divider class="my-3" />
-          <v-subheader class="font-weight-bold"
-            >Éléments fixes (X + Y)</v-subheader
-          >
-          <v-simple-table dense class="mb-2">
-            <thead>
-              <tr>
-                <th style="width:232px">Champ</th>
-                <th style="width:52px">Actif</th>
-                <th style="width:80px">Police</th>
-                <th style="width:42px">Coul.</th>
-                <th style="width:64px">Taille</th>
-                <th style="width:48px">Gras</th>
-                <th style="width:90px">X</th>
-                <th style="width:90px">Y</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="f in matchFCFields" :key="f.key">
-                <td class="caption font-weight-medium">{{ f.label }}</td>
-                <td>
-                  <v-switch
-                    v-model="settings.match[f.key].enabled"
-                    color="primary"
-                    inset
-                    dense
-                    hide-details
-                    class="mt-0 pt-0"
-                  />
-                </td>
-                <td>
-                  <v-combobox
-                    v-model="settings.match[f.key].font"
-                    :items="fontList"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <input
-                    type="color"
-                    v-model="settings.match[f.key].color"
-                    class="color-input"
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.match[f.key].size"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <v-checkbox
-                    v-model="settings.match[f.key].bold"
-                    hide-details
-                    class="mt-0 pt-0"
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.match[f.key].x"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.match[f.key].y"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-              </tr>
-            </tbody>
-          </v-simple-table>
+          <v-subheader class="font-weight-bold">Éléments fixes (X + Y)</v-subheader>
+          <image-f-c-table :fields="matchFCFields" :section="settings.match" :font-list="fontList" />
 
           <v-subheader class="font-weight-bold mt-2"
             >Lignes joueurs — Y
@@ -174,78 +94,8 @@
             /></v-col>
           </v-row>
 
-          <v-subheader class="font-weight-bold"
-            >Colonnes joueurs (X seul, Y = ligne)</v-subheader
-          >
-          <v-simple-table dense class="mb-2">
-            <thead>
-              <tr>
-                <th style="width:232px">Champ</th>
-                <th style="width:52px">Actif</th>
-                <th style="width:80px">Police</th>
-                <th style="width:42px">Coul.</th>
-                <th style="width:64px">Taille</th>
-                <th style="width:48px">Gras</th>
-                <th style="width:90px">X</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="f in matchFXFields" :key="f.key">
-                <td class="caption font-weight-medium">{{ f.label }}</td>
-                <td>
-                  <v-switch
-                    v-model="settings.match[f.key].enabled"
-                    color="primary"
-                    inset
-                    dense
-                    hide-details
-                    class="mt-0 pt-0"
-                  />
-                </td>
-                <td>
-                  <v-combobox
-                    v-model="settings.match[f.key].font"
-                    :items="fontList"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <input
-                    type="color"
-                    v-model="settings.match[f.key].color"
-                    class="color-input"
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.match[f.key].size"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <v-checkbox
-                    v-model="settings.match[f.key].bold"
-                    hide-details
-                    class="mt-0 pt-0"
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.match[f.key].x"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-              </tr>
-            </tbody>
-          </v-simple-table>
+          <v-subheader class="font-weight-bold">Colonnes joueurs (X seul, Y = ligne)</v-subheader>
+          <image-f-x-table :fields="matchFXFields" :section="settings.match" :font-list="fontList" />
 
           <v-divider class="my-3" />
           <v-subheader class="font-weight-bold">
@@ -745,85 +595,7 @@
         <!-- Tab 1 : Image Joueur                                          -->
         <!-- ══════════════════════════════════════════════════════════════ -->
         <v-card v-if="tab === 1" flat class="pa-4">
-          <v-simple-table dense class="mb-2">
-            <thead>
-              <tr>
-                <th style="width:232px">Champ</th>
-                <th style="width:52px">Actif</th>
-                <th style="width:80px">Police</th>
-                <th style="width:42px">Coul.</th>
-                <th style="width:64px">Taille</th>
-                <th style="width:48px">Gras</th>
-                <th style="width:90px">X</th>
-                <th style="width:90px">Y</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="f in playerFields" :key="f.key">
-                <td class="caption font-weight-medium">{{ f.label }}</td>
-                <td>
-                  <v-switch
-                    v-model="settings.player[f.key].enabled"
-                    color="primary"
-                    inset
-                    dense
-                    hide-details
-                    class="mt-0 pt-0"
-                  />
-                </td>
-                <td>
-                  <v-combobox
-                    v-model="settings.player[f.key].font"
-                    :items="fontList"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <input
-                    type="color"
-                    v-model="settings.player[f.key].color"
-                    class="color-input"
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.player[f.key].size"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <v-checkbox
-                    v-model="settings.player[f.key].bold"
-                    hide-details
-                    class="mt-0 pt-0"
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.player[f.key].x"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.player[f.key].y"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-              </tr>
-            </tbody>
-          </v-simple-table>
+          <image-f-c-table :fields="playerFields" :section="settings.player" :font-list="fontList" />
 
           <v-divider class="my-3" />
           <v-subheader class="font-weight-bold">
@@ -1398,48 +1170,58 @@
           </v-subheader>
 
           <v-divider class="my-3" />
+          <!-- ── Box derrière les noms de map ──────────────────────────────── -->
+          <v-subheader class="font-weight-bold">
+            Box derrière les noms de map
+            <v-switch
+              v-model="settings.mvp.shapes.enabled"
+              color="primary" inset dense hide-details class="ml-4 mt-0 pt-0"
+              label="Formes actives"
+            />
+          </v-subheader>
+          <div v-if="settings.mvp.shapes.enabled">
+            <v-row dense align="center">
+              <v-col cols="auto" class="d-flex align-center">
+                <v-switch v-model="settings.mvp.shapes.map_pill.enabled" label="Box map" color="primary" inset dense hide-details class="mt-0 pt-0" />
+              </v-col>
+            </v-row>
+            <v-row dense class="mt-1" v-if="settings.mvp.shapes.map_pill.enabled">
+              <v-col cols="1" class="d-flex align-center">
+                <input type="color" v-model="settings.mvp.shapes.map_pill.fill" class="color-input" />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.mvp.shapes.map_pill.alpha" label="Opacité (autres)" type="number" step="0.05" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.mvp.shapes.map_pill.current_alpha" label="Opacité (map en cours)" type="number" step="0.05" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.mvp.shapes.map_pill.radius" label="Rayon" type="number" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.mvp.shapes.map_pill.width" label="Largeur" type="number" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.mvp.shapes.map_pill.height" label="Hauteur" type="number" outlined dense hide-details />
+              </v-col>
+            </v-row>
+            <v-row dense class="mt-1" v-if="settings.mvp.shapes.map_pill.enabled">
+              <v-col cols="1" class="d-flex align-center">
+                <input type="color" v-model="settings.mvp.shapes.map_pill.border" class="color-input" />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.mvp.shapes.map_pill.border_alpha" label="Opacité bordure" type="number" step="0.05" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.mvp.shapes.map_pill.border_width" label="Épaisseur bordure" type="number" outlined dense hide-details />
+              </v-col>
+            </v-row>
+          </div>
+
+          <v-divider class="my-3" />
           <!-- ── Éléments textuels MVP ───────────────────────────────────── -->
           <v-subheader class="font-weight-bold">Éléments textuels</v-subheader>
-          <v-simple-table dense class="mb-2">
-            <thead>
-              <tr>
-                <th style="width:232px">Champ</th>
-                <th style="width:52px">Actif</th>
-                <th style="width:80px">Police</th>
-                <th style="width:42px">Coul.</th>
-                <th style="width:64px">Taille</th>
-                <th style="width:48px">Gras</th>
-                <th style="width:90px">X</th>
-                <th style="width:90px">Y</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="f in mvpFields" :key="f.key">
-                <td class="caption font-weight-medium">{{ f.label }}</td>
-                <td>
-                  <v-switch v-model="settings.mvp[f.key].enabled" color="primary" inset dense hide-details class="mt-0 pt-0" />
-                </td>
-                <td>
-                  <v-combobox v-model="settings.mvp[f.key].font" :items="fontList" outlined dense hide-details />
-                </td>
-                <td>
-                  <input type="color" v-model="settings.mvp[f.key].color" class="color-input" />
-                </td>
-                <td>
-                  <v-text-field v-model.number="settings.mvp[f.key].size" type="number" outlined dense hide-details />
-                </td>
-                <td>
-                  <v-checkbox v-model="settings.mvp[f.key].bold" hide-details class="mt-0 pt-0" />
-                </td>
-                <td>
-                  <v-text-field v-model.number="settings.mvp[f.key].x" type="number" outlined dense hide-details />
-                </td>
-                <td>
-                  <v-text-field v-model.number="settings.mvp[f.key].y" type="number" outlined dense hide-details />
-                </td>
-              </tr>
-            </tbody>
-          </v-simple-table>
+          <image-f-c-table :fields="mvpFields" :section="settings.mvp" :font-list="fontList" />
 
           <v-divider class="my-3" />
           <v-subheader class="font-weight-bold">
@@ -1469,10 +1251,10 @@
               <v-text-field v-model="settings.mvp.background" label="Fichier de fond (public/img/)" outlined dense />
             </v-col>
             <v-col cols="4">
-              <v-file-input v-model="bgFile[3]" label="Uploader un fond" accept="image/png,image/jpeg" outlined dense hide-details prepend-icon="mdi-image" />
+              <v-file-input v-model="bgFile[2]" label="Uploader un fond" accept="image/png,image/jpeg" outlined dense hide-details prepend-icon="mdi-image" />
             </v-col>
             <v-col cols="2">
-              <v-btn :disabled="!bgFile[3]" color="secondary" small @click="uploadBg(3)" :loading="uploadingBg[3]">
+              <v-btn :disabled="!bgFile[2]" color="secondary" small @click="uploadBg(2)" :loading="uploadingBg[2]">
                 <v-icon left>mdi-upload</v-icon>Uploader
               </v-btn>
             </v-col>
@@ -1482,100 +1264,22 @@
               <v-text-field v-model="settings.mvp.fontFile" label="Fichier police (public/fonts/)" outlined dense />
             </v-col>
             <v-col cols="4">
-              <v-file-input v-model="fontFileInput[3]" label="Uploader une police" accept=".ttf,.otf" outlined dense hide-details prepend-icon="mdi-format-font" />
+              <v-file-input v-model="fontFileInput[2]" label="Uploader une police" accept=".ttf,.otf" outlined dense hide-details prepend-icon="mdi-format-font" />
             </v-col>
             <v-col cols="2">
-              <v-btn :disabled="!fontFileInput[3]" color="secondary" small @click="uploadFont(3)" :loading="uploadingFont[3]">
+              <v-btn :disabled="!fontFileInput[2]" color="secondary" small @click="uploadFont(2)" :loading="uploadingFont[2]">
                 <v-icon left>mdi-upload</v-icon>Uploader
               </v-btn>
             </v-col>
           </v-row>
-          <v-alert v-if="uploadMsg[3]" :type="uploadMsgType[3]" dense class="mt-2">{{ uploadMsg[3] }}</v-alert>
+          <v-alert v-if="uploadMsg[2]" :type="uploadMsgType[2]" dense class="mt-2">{{ uploadMsg[2] }}</v-alert>
         </v-card>
 
         <!-- ══════════════════════════════════════════════════════════════ -->
         <!-- Tab 3 : Image Équipe Saison                                   -->
         <!-- ══════════════════════════════════════════════════════════════ -->
         <v-card v-if="tab === 3" flat class="pa-4">
-          <v-simple-table dense class="mb-2">
-            <thead>
-              <tr>
-                <th style="width:232px">Champ</th>
-                <th style="width:52px">Actif</th>
-                <th style="width:80px">Police</th>
-                <th style="width:42px">Coul.</th>
-                <th style="width:64px">Taille</th>
-                <th style="width:48px">Gras</th>
-                <th style="width:90px">X</th>
-                <th style="width:90px">Y</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="f in teamSeasonFields" :key="f.key">
-                <td class="caption font-weight-medium">{{ f.label }}</td>
-                <td>
-                  <v-switch
-                    v-model="settings.team_season[f.key].enabled"
-                    color="primary"
-                    inset
-                    dense
-                    hide-details
-                    class="mt-0 pt-0"
-                  />
-                </td>
-                <td>
-                  <v-combobox
-                    v-model="settings.team_season[f.key].font"
-                    :items="fontList"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <input
-                    type="color"
-                    v-model="settings.team_season[f.key].color"
-                    class="color-input"
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.team_season[f.key].size"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <v-checkbox
-                    v-model="settings.team_season[f.key].bold"
-                    hide-details
-                    class="mt-0 pt-0"
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.team_season[f.key].x"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="settings.team_season[f.key].y"
-                    type="number"
-                    outlined
-                    dense
-                    hide-details
-                  />
-                </td>
-              </tr>
-            </tbody>
-          </v-simple-table>
+          <image-f-c-table :fields="teamSeasonFields" :section="settings.team_season" :font-list="fontList" />
           <v-row dense class="mt-2">
             <v-col cols="4">
               <v-text-field
@@ -2285,7 +1989,7 @@
             /></v-col>
             <v-col cols="4"
               ><v-file-input
-                v-model="bgFile[2]"
+                v-model="bgFile[3]"
                 label="Uploader un fond"
                 accept="image/png,image/jpeg"
                 outlined
@@ -2295,11 +1999,11 @@
             /></v-col>
             <v-col cols="2"
               ><v-btn
-                :disabled="!bgFile[2]"
+                :disabled="!bgFile[3]"
                 color="secondary"
                 small
-                @click="uploadBg(2)"
-                :loading="uploadingBg[2]"
+                @click="uploadBg(3)"
+                :loading="uploadingBg[3]"
                 ><v-icon left>mdi-upload</v-icon>Uploader</v-btn
               ></v-col
             >
@@ -2314,7 +2018,7 @@
             /></v-col>
             <v-col cols="4"
               ><v-file-input
-                v-model="fontFileInput[2]"
+                v-model="fontFileInput[3]"
                 label="Uploader une police"
                 accept=".ttf,.otf"
                 outlined
@@ -2324,18 +2028,18 @@
             /></v-col>
             <v-col cols="2"
               ><v-btn
-                :disabled="!fontFileInput[2]"
+                :disabled="!fontFileInput[3]"
                 color="secondary"
                 small
-                @click="uploadFont(2)"
-                :loading="uploadingFont[2]"
+                @click="uploadFont(3)"
+                :loading="uploadingFont[3]"
                 ><v-icon left>mdi-upload</v-icon>Uploader</v-btn
               ></v-col
             >
           </v-row>
           <v-alert
-            v-if="uploadMsg[2]"
-            :type="uploadMsgType[2]"
+            v-if="uploadMsg[3]"
+            :type="uploadMsgType[3]"
             dense
             class="mt-2"
             >{{ uploadMsg[2] }}</v-alert
@@ -2573,6 +2277,9 @@
 </template>
 
 <script>
+import ImageFCTable from "@/components/ImageFCTable.vue";
+import ImageFXTable from "@/components/ImageFXTable.vue";
+
 const defFC = (enabled, font, color, size, bold, x, y) => ({
   enabled,
   font,
@@ -2593,6 +2300,7 @@ const defFX = (enabled, font, color, size, bold, x) => ({
 
 export default {
   name: "ImageSettings",
+  components: { ImageFCTable, ImageFXTable },
   data() {
     return {
       loading: true,

--- a/src/views/ImageSettings.vue
+++ b/src/views/ImageSettings.vue
@@ -1170,6 +1170,59 @@
           </v-subheader>
 
           <v-divider class="my-3" />
+          <!-- ── Éléments graphiques MVP ────────────────────────────────────── -->
+          <v-subheader class="font-weight-bold">
+            Éléments graphiques
+            <v-switch v-model="settings.mvp.shapes.enabled" color="primary" inset dense hide-details class="ml-4 mt-0 pt-0" />
+          </v-subheader>
+          <div v-if="settings.mvp.shapes.enabled">
+            <!-- Team pill -->
+            <v-subheader class="caption font-weight-bold pl-0">Pilule nom d'équipe</v-subheader>
+            <v-row dense>
+              <v-col cols="1" class="d-flex align-center">
+                <v-switch v-model="settings.mvp.shapes.team_pill.enabled" label="Actif" color="primary" inset dense hide-details class="mt-0 pt-0" />
+              </v-col>
+              <v-col cols="1" class="d-flex align-center"><input type="color" v-model="settings.mvp.shapes.team_pill.fill" class="color-input" /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.team_pill.alpha" label="Opacité" type="number" step="0.05" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.team_pill.radius" label="Rayon" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.team_pill.width" label="Largeur" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.team_pill.height" label="Hauteur" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1" class="d-flex align-center"><input type="color" v-model="settings.mvp.shapes.team_pill.border" class="color-input" /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.team_pill.border_alpha" label="Op. bord." type="number" step="0.05" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.team_pill.border_width" label="Ép. bord." type="number" outlined dense hide-details /></v-col>
+            </v-row>
+            <!-- Player pill -->
+            <v-subheader class="caption font-weight-bold pl-0 mt-2">Pilule nom du joueur</v-subheader>
+            <v-row dense>
+              <v-col cols="1" class="d-flex align-center">
+                <v-switch v-model="settings.mvp.shapes.player_pill.enabled" label="Actif" color="primary" inset dense hide-details class="mt-0 pt-0" />
+              </v-col>
+              <v-col cols="1" class="d-flex align-center"><input type="color" v-model="settings.mvp.shapes.player_pill.fill" class="color-input" /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.player_pill.alpha" label="Opacité" type="number" step="0.05" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.player_pill.radius" label="Rayon" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.player_pill.width" label="Largeur" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.player_pill.height" label="Hauteur" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1" class="d-flex align-center"><input type="color" v-model="settings.mvp.shapes.player_pill.border" class="color-input" /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.player_pill.border_alpha" label="Op. bord." type="number" step="0.05" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.player_pill.border_width" label="Ép. bord." type="number" outlined dense hide-details /></v-col>
+            </v-row>
+            <!-- Stats bar -->
+            <v-subheader class="caption font-weight-bold pl-0 mt-2">Barre stats</v-subheader>
+            <v-row dense>
+              <v-col cols="1" class="d-flex align-center">
+                <v-switch v-model="settings.mvp.shapes.stats_bar.enabled" label="Actif" color="primary" inset dense hide-details class="mt-0 pt-0" />
+              </v-col>
+              <v-col cols="1" class="d-flex align-center"><input type="color" v-model="settings.mvp.shapes.stats_bar.fill" class="color-input" /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.stats_bar.alpha" label="Opacité" type="number" step="0.05" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.stats_bar.radius" label="Rayon" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.stats_bar.x" label="X" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.stats_bar.y" label="Y (0=auto)" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.stats_bar.width" label="Largeur" type="number" outlined dense hide-details /></v-col>
+              <v-col cols="1"><v-text-field v-model.number="settings.mvp.shapes.stats_bar.height" label="Hauteur" type="number" outlined dense hide-details /></v-col>
+            </v-row>
+          </div>
+
+          <v-divider class="my-3" />
           <!-- ── Box derrière les noms de map ──────────────────────────────── -->
           <v-subheader class="font-weight-bold">
             Box derrière les noms de map

--- a/src/views/ImageSettings.vue
+++ b/src/views/ImageSettings.vue
@@ -1174,18 +1174,12 @@
           <v-subheader class="font-weight-bold">
             Box derrière les noms de map
             <v-switch
-              v-model="settings.mvp.shapes.enabled"
+              v-model="settings.mvp.shapes.map_pill.enabled"
               color="primary" inset dense hide-details class="ml-4 mt-0 pt-0"
-              label="Formes actives"
             />
           </v-subheader>
-          <div v-if="settings.mvp.shapes.enabled">
-            <v-row dense align="center">
-              <v-col cols="auto" class="d-flex align-center">
-                <v-switch v-model="settings.mvp.shapes.map_pill.enabled" label="Box map" color="primary" inset dense hide-details class="mt-0 pt-0" />
-              </v-col>
-            </v-row>
-            <v-row dense class="mt-1" v-if="settings.mvp.shapes.map_pill.enabled">
+          <div v-if="settings.mvp.shapes.map_pill.enabled">
+            <v-row dense class="mt-1">
               <v-col cols="1" class="d-flex align-center">
                 <input type="color" v-model="settings.mvp.shapes.map_pill.fill" class="color-input" />
               </v-col>
@@ -1205,7 +1199,7 @@
                 <v-text-field v-model.number="settings.mvp.shapes.map_pill.height" label="Hauteur" type="number" outlined dense hide-details />
               </v-col>
             </v-row>
-            <v-row dense class="mt-1" v-if="settings.mvp.shapes.map_pill.enabled">
+            <v-row dense class="mt-1">
               <v-col cols="1" class="d-flex align-center">
                 <input type="color" v-model="settings.mvp.shapes.map_pill.border" class="color-input" />
               </v-col>

--- a/src/views/ImageSettings.vue
+++ b/src/views/ImageSettings.vue
@@ -496,6 +496,49 @@
           </div>
 
           <v-divider class="my-3" />
+          <!-- ── Box derrière les noms de map ──────────────────────────────── -->
+          <v-subheader class="font-weight-bold">
+            Box derrière les noms de map
+            <v-switch
+              v-model="settings.match.shapes.map_pill.enabled"
+              color="primary" inset dense hide-details class="ml-4 mt-0 pt-0"
+            />
+          </v-subheader>
+          <div v-if="settings.match.shapes.map_pill.enabled">
+            <v-row dense class="mt-1">
+              <v-col cols="1" class="d-flex align-center">
+                <input type="color" v-model="settings.match.shapes.map_pill.fill" class="color-input" />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.match.shapes.map_pill.alpha" label="Opacité (autres)" type="number" step="0.05" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.match.shapes.map_pill.current_alpha" label="Opacité (map en cours)" type="number" step="0.05" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.match.shapes.map_pill.radius" label="Rayon" type="number" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.match.shapes.map_pill.width" label="Largeur" type="number" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.match.shapes.map_pill.height" label="Hauteur" type="number" outlined dense hide-details />
+              </v-col>
+            </v-row>
+            <v-row dense class="mt-1">
+              <v-col cols="1" class="d-flex align-center">
+                <input type="color" v-model="settings.match.shapes.map_pill.border" class="color-input" />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.match.shapes.map_pill.border_alpha" label="Opacité bordure" type="number" step="0.05" outlined dense hide-details />
+              </v-col>
+              <v-col cols="2">
+                <v-text-field v-model.number="settings.match.shapes.map_pill.border_width" label="Épaisseur bordure" type="number" outlined dense hide-details />
+              </v-col>
+            </v-row>
+          </div>
+
+          <v-divider class="my-3" />
           <v-subheader class="font-weight-bold">
             Logos d'équipes (position &amp; taille)
           </v-subheader>
@@ -2365,7 +2408,9 @@ export default {
           team1_score: defFC(true, "Arial", "#1a1a2e", 30, true, 806, 302),
           team2_score: defFC(true, "Arial", "#1a1a2e", 30, true, 1114, 302),
           team2_name: defFC(true, "Arial", "#1a1a2e", 30, true, 1595, 302),
-          map_name: defFC(true, "Arial", "#1a1a2e", 28, true, 960, 980),
+          map1: defFC(true, "Arial", "#1a1a2e", 24, true, 480, 980),
+          map2: defFC(true, "Arial", "#1a1a2e", 24, true, 960, 980),
+          map3: defFC(true, "Arial", "#1a1a2e", 24, true, 1440, 980),
           player_name_l: defFX(true, "Arial", "#1a1a2e", 20, true, 180),
           player_name_r: defFX(true, "Arial", "#1a1a2e", 20, true, 1450),
           kills_l: defFX(true, "Arial", "#1a1a2e", 20, false, 630),
@@ -2430,6 +2475,18 @@ export default {
               odd_alpha: 0.08,
               even_fill: "#ffffff",
               even_alpha: 0.05
+            },
+            map_pill: {
+              enabled: true,
+              fill: "#000000",
+              alpha: 0.3,
+              current_alpha: 0.7,
+              radius: 8,
+              width: 280,
+              height: 40,
+              border: "#ffffff",
+              border_alpha: 0.2,
+              border_width: 1
             }
           }
         },
@@ -2673,7 +2730,9 @@ export default {
         { key: "team1_score", label: "Score équipe 1" },
         { key: "team2_score", label: "Score équipe 2" },
         { key: "team2_name", label: "Nom équipe 2" },
-        { key: "map_name", label: "Nom de la map" }
+        { key: "map1", label: "Map 1 (gauche)" },
+        { key: "map2", label: "Map 2 (centre)" },
+        { key: "map3", label: "Map 3 (droite)" }
       ],
       matchFXFields: [
         { key: "player_name_l", label: "Nom joueur gauche" },
@@ -2788,6 +2847,10 @@ export default {
               stats_table: {
                 ...def.match.shapes.stats_table,
                 ...(sm.shapes?.stats_table || {})
+              },
+              map_pill: {
+                ...def.match.shapes.map_pill,
+                ...(sm.shapes?.map_pill || {})
               }
             }
           },


### PR DESCRIPTION
## Summary
- Cleanup of the image generator settings UI (ImageFCTable/ImageFXTable components) for Match, MVP and Team Season tabs
- MVP image: added a configurable box behind map names (`map_pill`), with higher opacity for the current map, BO1 centering, and BO3 shows all 3 planned maps (even unplayed) using veto picks
- Applied the same map box / current-map highlight / BO1-centering / BO3-unplayed-maps logic to the "stats" match image (map1/map2/map3 slots replacing the old single multiline map field)
- Fixed CastView "Pages" column button spacing
- Added admin-only buttons on `/matches` to pause/unpause all currently live matches, with i18n (EN/FR/JP)

## Test plan
- [ ] Verify MVP and stats images render correctly for BO1/BO3, played and unplayed maps
- [ ] Verify ImageSettings UI saves/loads correctly for match/mvp/team_season tabs
- [ ] Verify pause/unpause all live matches works as admin on `/matches`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9kq5XTicQXGJrJ1Ndg4hY)_