### PR TITLE
Add challonge_slug to match form submission

### DIFF
--- a/src/components/ChallongeMatchForm.vue
+++ b/src/components/ChallongeMatchForm.vue
@@ -299,6 +299,7 @@ export default {
           team2_id: this.prefill.team2.id,
           season_id: this.prefill.season_id,
           challonge_id: this.prefill.challonge_match_id ?? null,
+          challonge_slug: this.prefill.challonge_match?.slug ?? null,
           start_time: new Date().toISOString().slice(0, 19).replace("T", " "),
           max_maps: this.formData.maps_to_win,
           spectator_auths: this.formData.spectators.length


### PR DESCRIPTION
## Summary
Add the `challonge_slug` field to the match form data submitted when creating or updating a match in the ChallongeMatchForm component.

## Changes
- **ChallongeMatchForm.vue**: Added `challonge_slug` field to the form submission payload, extracting it from `this.prefill.challonge_match?.slug` with a fallback to `null`

## Details
This change ensures that when a match is submitted through the Challonge match form, the Challonge match slug is included in the API request payload alongside the existing `challonge_id`. This allows the backend to properly track and reference the Challonge match by its slug identifier, which is useful for API integrations and match lookups.

The slug is safely extracted using optional chaining (`?.`) to handle cases where the Challonge match data may not be available.

https://claude.ai/code/session_01CLVgPftobzjWpszmfdvo5k