### PR TITLE
Replace TV 0s link with copy-to-clipboard for GOTV connect

### DIFF
--- a/src/views/CastView.vue
+++ b/src/views/CastView.vue
@@ -116,10 +116,9 @@
                         x-small
                         dark
                         color="deep-purple"
-                        :href="connectUrl(match, 'tv0')"
-                        target="_blank"
+                        @click="copyConnectText(match)"
                       >
-                        <v-icon x-small left>mdi-television-play</v-icon>TV 0s
+                        <v-icon x-small left>mdi-content-copy</v-icon>TV 0s
                       </v-btn>
                     </div>
                   </td>
@@ -379,6 +378,10 @@
         </v-col>
       </v-row>
     </template>
+
+    <v-snackbar v-model="copySnackbar" :color="copySnackbarColor" timeout="3000">
+      {{ copyMessage }}
+    </v-snackbar>
   </v-container>
 </template>
 
@@ -395,6 +398,9 @@ export default {
       activeMatches: [],
       finishedMatches: [],
       sseClient: null,
+      copySnackbar: false,
+      copyMessage: "",
+      copySnackbarColor: "success",
     };
   },
   computed: {
@@ -446,10 +452,49 @@ export default {
         return `${base}+connect%20${ip}:${match.port}`;
       }
       if (!match.gotv_port) return "#";
-      if (type === "tv90") {
-        return `${base}+connect%20${ip}:${match.gotv_port}`;
+      return `${base}+connect%20${ip}:${match.gotv_port}`;
+    },
+
+    gotvConnectText(match) {
+      const ip = match.ip_cast || match.ip_string;
+      if (!ip || !match.gotv_port) return "";
+      return `connect ${ip}:${match.gotv_port + 100}; password croissant`;
+    },
+
+    legacyCopyToClipboard(text) {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.top = "0";
+      textarea.style.left = "0";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      textarea.setSelectionRange(0, text.length);
+      const succeeded = document.execCommand("copy");
+      document.body.removeChild(textarea);
+      if (!succeeded) throw new Error("execCommand copy failed");
+    },
+
+    async copyConnectText(match) {
+      const text = this.gotvConnectText(match);
+      if (!text) return;
+      try {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+        } else {
+          this.legacyCopyToClipboard(text);
+        }
+        this.copyMessage = "Commande copiée : " + text;
+        this.copySnackbarColor = "success";
+      } catch (error) {
+        void error;
+        this.copyMessage = "Échec de la copie";
+        this.copySnackbarColor = "error";
       }
-      return `${base}+connect%20${ip}:${match.gotv_port + 100}; password croissant`;
+      this.copySnackbar = true;
     },
 
     mapShortName(map) {


### PR DESCRIPTION
## Summary

Changed the "TV 0s" button in CastView from opening an external link to copying a GOTV connect command to the clipboard, with user feedback via snackbar notification.

## Key Changes

- **Button behavior**: Replaced `href` + `target="_blank"` with `@click="copyConnectText(match)"` handler
- **Icon update**: Changed from `mdi-television-play` to `mdi-content-copy` to reflect the new copy action
- **New method `gotvConnectText(match)`**: Generates the GOTV connect command string (`connect {ip}:{port+100}; password croissant`)
- **New method `copyConnectText(match)`**: Handles clipboard copy with fallback support:
  - Uses modern `navigator.clipboard` API when available (secure context)
  - Falls back to legacy `execCommand('copy')` for older browsers
- **New method `legacyCopyToClipboard(text)`**: Implements the legacy copy mechanism using textarea manipulation
- **Snackbar feedback**: Added `v-snackbar` component to display success/error messages in French
- **Data properties**: Added `copySnackbar`, `copyMessage`, and `copySnackbarColor` to manage snackbar state

## Implementation Details

- The GOTV connect command includes the port offset (+100) and hardcoded password as per existing logic
- Error handling gracefully degrades: if copy fails, user sees "Échec de la copie" error message
- Success message displays the copied command for confirmation: "Commande copiée : {text}"
- Snackbar auto-dismisses after 3 seconds
- Maintains consistency with French UI language conventions

https://claude.ai/code/session_01WjDBShpdPgDvW8MQADF5fa