### PR TITLE
Télécharger les images stats/mvp au lieu de les ouvrir en onglet

### DIFF
--- a/src/components/PlayerStatTable.vue
+++ b/src/components/PlayerStatTable.vue
@@ -6,7 +6,7 @@
           small
           color="warning"
           :href="apiUrl + '/image/match/' + match_id + '/mvp'"
-          target="_blank"
+          :download="'match-' + match_id + '-mvp.png'"
         >
           <v-icon left small>mdi-star</v-icon>
           MVP Match
@@ -69,7 +69,9 @@
               :href="
                 apiUrl + '/image/match/' + match_id + '/map/' + (index + 1)
               "
-              target="_blank"
+              :download="
+                'match-' + match_id + '-map-' + (index + 1) + '.png'
+              "
               class="mr-2"
             >
               <v-icon left small>mdi-image</v-icon>
@@ -86,7 +88,9 @@
                 (index + 1) +
                 '/mvp'
               "
-              target="_blank"
+              :download="
+                'match-' + match_id + '-map-' + (index + 1) + '-mvp.png'
+              "
             >
               <v-icon left small>mdi-star</v-icon>
               MVP Image
@@ -140,7 +144,7 @@
                   small
                   color="secondary"
                   :href="GetPlayerImageUrl(match_id, item.steam_id)"
-                  target="_blank"
+                  :download="'match-' + match_id + '-player-' + item.steam_id + '.png'"
                   class="mr-2"
                 >
                   <v-icon left small>mdi-image</v-icon>
@@ -158,7 +162,15 @@
                     '/player/' +
                     item.steam_id
                   "
-                  target="_blank"
+                  :download="
+                    'match-' +
+                    match_id +
+                    '-map-' +
+                    (index + 1) +
+                    '-player-' +
+                    item.steam_id +
+                    '.png'
+                  "
                 >
                   <v-icon left small>mdi-image-filter-center-focus</v-icon>
                   Stat Image Map

--- a/src/views/CastView.vue
+++ b/src/views/CastView.vue
@@ -140,7 +140,13 @@
                             '/map/' +
                             (map.map_number + 1)
                           "
-                          target="_blank"
+                          :download="
+                            'match-' +
+                            match.id +
+                            '-map-' +
+                            (map.map_number + 1) +
+                            '.png'
+                          "
                         >
                           <v-icon x-small left>mdi-chart-bar</v-icon>Map
                           {{ map.map_number + 1 }}
@@ -156,7 +162,13 @@
                             (map.map_number + 1) +
                             '/mvp'
                           "
-                          target="_blank"
+                          :download="
+                            'match-' +
+                            match.id +
+                            '-map-' +
+                            (map.map_number + 1) +
+                            '-mvp.png'
+                          "
                         >
                           <v-icon x-small left>mdi-star</v-icon>MVP
                         </v-btn>
@@ -167,7 +179,7 @@
                           dark
                           color="teal darken-2"
                           :href="'/api/image/match/' + match.id"
-                          target="_blank"
+                          :download="'match-' + match.id + '.png'"
                         >
                           <v-icon x-small left>mdi-chart-bar</v-icon>Stats Match
                         </v-btn>
@@ -176,7 +188,7 @@
                           dark
                           color="warning"
                           :href="'/api/image/match/' + match.id + '/mvp'"
-                          target="_blank"
+                          :download="'match-' + match.id + '-mvp.png'"
                         >
                           <v-icon x-small left>mdi-star-circle</v-icon>MVP Match
                         </v-btn>
@@ -274,7 +286,13 @@
                             '/map/' +
                             (map.map_number + 1)
                           "
-                          target="_blank"
+                          :download="
+                            'match-' +
+                            match.id +
+                            '-map-' +
+                            (map.map_number + 1) +
+                            '.png'
+                          "
                         >
                           <v-icon x-small left>mdi-chart-bar</v-icon>Map
                           {{ map.map_number + 1 }}
@@ -290,7 +308,13 @@
                             (map.map_number + 1) +
                             '/mvp'
                           "
-                          target="_blank"
+                          :download="
+                            'match-' +
+                            match.id +
+                            '-map-' +
+                            (map.map_number + 1) +
+                            '-mvp.png'
+                          "
                         >
                           <v-icon x-small left>mdi-star</v-icon>MVP
                         </v-btn>
@@ -301,7 +325,7 @@
                           dark
                           color="teal darken-2"
                           :href="'/api/image/match/' + match.id"
-                          target="_blank"
+                          :download="'match-' + match.id + '.png'"
                         >
                           <v-icon x-small left>mdi-chart-bar</v-icon>Stats Match
                         </v-btn>
@@ -310,7 +334,7 @@
                           dark
                           color="warning"
                           :href="'/api/image/match/' + match.id + '/mvp'"
-                          target="_blank"
+                          :download="'match-' + match.id + '-mvp.png'"
                         >
                           <v-icon x-small left>mdi-star-circle</v-icon>MVP Match
                         </v-btn>


### PR DESCRIPTION
## Summary
- Les boutons pointant vers les images générées par G5API (match, mvp, joueur) dans `PlayerStatTable.vue` et `CastView.vue` utilisaient `target="_blank"`, ce qui ouvre le PNG dans le visualiseur d'image natif de Chrome.
- Ce visualiseur peint un fond `background-color: hsl(0, 0%, 90%)` par-dessus les zones transparentes de l'image, ce qui posait problème pour une utilisation en Browser Source OBS.
- Remplacement de `target="_blank"` par `download="<nom-fichier>.png"` sur tous ces boutons : le clic télécharge directement le PNG au lieu de l'ouvrir en onglet, donc plus de visualiseur Chrome et plus de fond gris.

## Test plan
- [ ] Vérifier que chaque bouton (`MVP Match`, `Stat Image`, `MVP Image`, `Stat Image Map`, `Map X`, `Stats Match`) télécharge bien le PNG avec un nom de fichier cohérent
- [ ] Vérifier que le fichier téléchargé conserve la transparence (pas de fond gris)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N6PWmg3DX9wXw3tjBJNDYr)_